### PR TITLE
Use sorted 2.0.0

### DIFF
--- a/lib/sorted/orms/mongoid.rb
+++ b/lib/sorted/orms/mongoid.rb
@@ -6,12 +6,12 @@ module Sorted
   module Orms
     module Mongoid
       extend ActiveSupport::Concern
-      SQL_TO_MONGO = { "asc" => 1, "desc" => -1 } 
-
       included do
         def self.sorted(sort, default_order = nil)
-          sorter = ::Sorted::Parser.new(sort, default_order)
-          order_by sorter.to_hash.merge(sorter) { |key, val| SQL_TO_MONGO[val] }
+          uri = ::Sorted::URIQuery.parse(sort)
+          sql = ::Sorted::SQLQuery.parse(default_order)
+          set = uri + (sql - uri)
+          order_by ::Sorted::JSONQuery.encode(set)
         end
       end
     end

--- a/sorted-mongoid.gemspec
+++ b/sorted-mongoid.gemspec
@@ -20,8 +20,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rspec", ">= 2.0.0"
+  spec.add_development_dependency "rake"
 
   spec.add_dependency 'activesupport', '>= 3.0.0'
-  spec.add_dependency "sorted", "~> 0.4.3"
+  spec.add_dependency "sorted", "~> 2.0.0"
   spec.add_dependency "mongoid", ">= 3.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,5 +2,4 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'sorted'
 require 'sorted/orms/mongoid'
-require 'sorted/view_helpers/action_view'
 require 'rspec'


### PR DESCRIPTION
The new version of sorted is just a generic sorting lib with all the orm stuff
removed so from now on if anyone wants to use sorted and mongo they will need
this gem.
